### PR TITLE
Removing the master-slave phrasing

### DIFF
--- a/blog/migrations/0007_auto_20200218_1500.py
+++ b/blog/migrations/0007_auto_20200218_1500.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterModelOptions(
-            name='slave',
+            name='subordinate',
             options={'verbose_name': 'Раб', 'verbose_name_plural': 'Раби'},
         ),
     ]

--- a/blog/migrations/0008_auto_20200218_1722.py
+++ b/blog/migrations/0008_auto_20200218_1722.py
@@ -19,27 +19,27 @@ class Migration(migrations.Migration):
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='email',
             field=models.CharField(blank=True, max_length=100, null=True, verbose_name='Email'),
         ),
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='file',
             field=models.FileField(blank=True, null=True, upload_to='', verbose_name='Файл'),
         ),
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='name',
             field=models.CharField(blank=True, max_length=150, null=True, verbose_name="Ім'я"),
         ),
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='phone',
             field=models.CharField(blank=True, max_length=50, null=True, verbose_name='Телефон'),
         ),
         migrations.AlterField(
-            model_name='slave',
+            model_name='subordinate',
             name='vacancy',
             field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='blog.Vacancy', verbose_name='Вакансія'),
         ),

--- a/project/urls.py
+++ b/project/urls.py
@@ -19,7 +19,7 @@ urlpatterns = [
     path('STO/', STO, name='STO'),
     path('get_vacancy/', get_vacancy, name='get_vacancy'),
     path('client/', client, name='client'),
-    path('get_slave/', get_slave, name='get_slave'),
+    path('get_subordinate/', get_subordinate, name='get_subordinate'),
 ]
 
 

--- a/project/views.py
+++ b/project/views.py
@@ -81,6 +81,6 @@ def get_vacancy(request):
 
 
 @csrf_exempt
-def get_slave(request):
+def get_subordinate(request):
 
     return JsonResponse({})


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.